### PR TITLE
Fix InvalidOperationException Cannot find compilation library location for package 'Weapsy.Apps.Text'.

### DIFF
--- a/src/Apps/Weapsy.Apps.Text/Weapsy.Apps.Text.csproj
+++ b/src/Apps/Weapsy.Apps.Text/Weapsy.Apps.Text.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -10,6 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <PreserveCompilationContext>false</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
VS 2017's NET.Sdk.Web has PreserveCompilationContext set to true by default, which causes DependencyModel errors when using it from an extension that is not loaded from the main app's bin directory.  This is equivalent to the VS2015 behavior since preserveCompilationContext was not set in the project.json.

@lucabriguglia 