### PR TITLE
Fixed issue with starting using a provider different than "MSSQL"

### DIFF
--- a/src/Weapsy/Startup.cs
+++ b/src/Weapsy/Startup.cs
@@ -32,6 +32,7 @@ using Weapsy.Framework.Queries;
 using Weapsy.Mvc.Extensions;
 using Weapsy.Reporting.Themes;
 using Weapsy.Reporting.Themes.Queries;
+using Microsoft.Extensions.Options;
 
 namespace Weapsy
 {
@@ -68,6 +69,12 @@ namespace Weapsy
             var hostingEnvironment = services.BuildServiceProvider().GetService<IHostingEnvironment>();
 
             services.AddOptions();
+
+            services.Configure<Weapsy.Data.Configuration.Data>(c => {
+                c.Provider = (Data.Configuration.DataProvider)Enum.Parse(
+                    typeof(Data.Configuration.DataProvider), 
+                    Configuration.GetSection("Data")["Provider"]);
+            });
 
             services.Configure<ConnectionStrings>(Configuration.GetSection("ConnectionStrings"));
 


### PR DESCRIPTION
Fix for issue #47.

There is a problem with a missing IOptions<Weapsy.Data.Configuration.Data> (provider defaults to MSSQL)..

This will probably also fix issue #28 